### PR TITLE
Add unit tests for callbacks

### DIFF
--- a/datadoc/Callbacks.py
+++ b/datadoc/Callbacks.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 from pydantic import ValidationError
 
@@ -47,3 +47,25 @@ def accept_variable_metadata_input(
             print(f"Successfully updated {updated_row_id} with {new_value}")
 
     return output_data, show_error, error_explanation
+
+
+def accept_dataset_metadata_input(
+    value: Any, metadata_identifier: str
+) -> Tuple[bool, str]:
+    try:
+        # Update the value in the model
+        setattr(
+            globals.metadata.dataset_metadata,
+            metadata_identifier,
+            value,
+        )
+    except ValidationError as e:
+        show_error = True
+        error_explanation = f"`{e}`"
+        print(error_explanation)
+    else:
+        show_error = False
+        error_explanation = ""
+        print(f"Successfully updated {metadata_identifier} with {value}")
+
+    return show_error, error_explanation

--- a/datadoc/Callbacks.py
+++ b/datadoc/Callbacks.py
@@ -1,0 +1,46 @@
+from typing import Dict, List, Tuple
+
+from pydantic import ValidationError
+
+from datadoc.DisplayVariables import VariableIdentifiers
+import globals
+
+
+def accept_variable_metadata_input(
+    data: List[Dict], data_previous: List[Dict]
+) -> Tuple[List[Dict], bool, str]:
+    updated_row_id = None
+    updated_column_id = None
+    new_value = None
+    show_error = False
+    error_explanation = ""
+    output_data = []
+    # What has changed?
+    for i in range(len(data)):
+        update_diff = list(data[i].items() - data_previous[i].items())
+        if update_diff:
+            updated_row_id = data[i][VariableIdentifiers.SHORT_NAME.value]
+            updated_column_id = update_diff[-1][0]
+            new_value = update_diff[-1][-1]
+            print(
+                f"Row: {updated_row_id} Column: {updated_column_id} New value: {new_value}"
+            )
+            break
+
+    try:
+        # Write the value to the variables structure
+        setattr(
+            globals.metadata.variables_metadata[updated_row_id],
+            updated_column_id,
+            new_value,
+        )
+    except ValidationError as e:
+        show_error = True
+        error_explanation = f"`{e}`"
+        output_data = data_previous
+        print(error_explanation)
+    else:
+        output_data = data
+        print(f"Successfully updated {updated_row_id} with {new_value}")
+
+    return output_data, show_error, error_explanation

--- a/datadoc/Callbacks.py
+++ b/datadoc/Callbacks.py
@@ -2,8 +2,8 @@ from typing import Dict, List, Tuple
 
 from pydantic import ValidationError
 
+import datadoc.globals as globals
 from datadoc.DisplayVariables import VariableIdentifiers
-import globals
 
 
 def accept_variable_metadata_input(
@@ -14,33 +14,36 @@ def accept_variable_metadata_input(
     new_value = None
     show_error = False
     error_explanation = ""
-    output_data = []
+    output_data = data
+    update_diff = []
     # What has changed?
     for i in range(len(data)):
         update_diff = list(data[i].items() - data_previous[i].items())
         if update_diff:
+            print(data)
+            print(data_previous)
             updated_row_id = data[i][VariableIdentifiers.SHORT_NAME.value]
             updated_column_id = update_diff[-1][0]
             new_value = update_diff[-1][-1]
             print(
                 f"Row: {updated_row_id} Column: {updated_column_id} New value: {new_value}"
             )
-            break
+            break  # We're only interested in one change so we break here
 
-    try:
-        # Write the value to the variables structure
-        setattr(
-            globals.metadata.variables_metadata[updated_row_id],
-            updated_column_id,
-            new_value,
-        )
-    except ValidationError as e:
-        show_error = True
-        error_explanation = f"`{e}`"
-        output_data = data_previous
-        print(error_explanation)
-    else:
-        output_data = data
-        print(f"Successfully updated {updated_row_id} with {new_value}")
+    if update_diff:
+        try:
+            # Write the value to the variables structure
+            setattr(
+                globals.metadata.variables_metadata[updated_row_id],
+                updated_column_id,
+                new_value,
+            )
+        except ValidationError as e:
+            show_error = True
+            error_explanation = f"`{e}`"
+            output_data = data_previous
+            print(error_explanation)
+        else:
+            print(f"Successfully updated {updated_row_id} with {new_value}")
 
     return output_data, show_error, error_explanation

--- a/datadoc/DataDocDash.py
+++ b/datadoc/DataDocDash.py
@@ -395,12 +395,10 @@ def main(dash_class: Type[Dash], dataset_path: str) -> Dash:
     @app.callback(
         Output("success-message", "is_open"),
         Input("save-button", "n_clicks"),
-        State("variables-table", "data"),
         prevent_initial_call=True,
     )
-    def save_metadata_file(n_clicks, data):
+    def callback_save_metadata_file(n_clicks):
         if n_clicks and n_clicks > 0:
-            print(data)
             globals.metadata.write_metadata_document()
             return True
         else:
@@ -414,9 +412,8 @@ def main(dash_class: Type[Dash], dataset_path: str) -> Dash:
     )
     def callback_accept_dataset_metadata_input(value: Any) -> Tuple[bool, str]:
         # Get the ID of the input that changed. This MUST match the attribute name defined in DataDocDataSet
-        metadata_identifier = ctx.triggered_id["id"]
         return accept_dataset_metadata_input(
-            ctx.triggered[0]["value"], metadata_identifier
+            ctx.triggered[0]["value"], ctx.triggered_id["id"]
         )
 
     @app.callback(

--- a/datadoc/DataDocDash.py
+++ b/datadoc/DataDocDash.py
@@ -1,15 +1,16 @@
-import re
 import argparse
+import re
 from typing import Dict, List, Tuple, Type
-from dash import Dash, dash_table, html, Input, Output, dcc, State, MATCH, ctx
-import dash_bootstrap_components as dbc
 
+import dash_bootstrap_components as dbc
+from dash import MATCH, Dash, Input, Output, State, ctx, dash_table, dcc, html
+
+import datadoc.globals as globals
+from datadoc.Callbacks import accept_variable_metadata_input
 from datadoc.DataDocMetadata import DataDocMetadata
-import globals
 from datadoc.DisplayVariables import DISPLAY_VARIABLES
 from datadoc.Model import DataSetState
 from datadoc.utils import running_in_notebook
-from datadoc.Callbacks import accept_variable_metadata_input
 
 
 def main(dash_class: Type[Dash], dataset_path: str) -> Dash:

--- a/datadoc/DataDocMetadata.py
+++ b/datadoc/DataDocMetadata.py
@@ -1,19 +1,18 @@
-from copy import deepcopy
-import json
-import pathlib
 import datetime
+import json
 import os
+import pathlib
+from copy import deepcopy
 from typing import Dict, List, Optional
-from datadoc.DisplayVariables import VariableIdentifiers
 
+from datadoc.DatasetReader import DatasetReader
+from datadoc.DisplayVariables import VariableIdentifiers
 from datadoc.Model import (
     AdministrativeStatus,
     DataDocDataSet,
     DataDocVariable,
     DataSetState,
 )
-
-from datadoc.DatasetReader import DatasetReader
 
 
 class DataDocMetadata:

--- a/datadoc/globals.py
+++ b/datadoc/globals.py
@@ -1,4 +1,11 @@
 from datadoc.DataDocMetadata import DataDocMetadata
 
+# DANGER: This global is safe when Datadoc is run as designed, with
+# an individual instance per user run within a Jupyter Notebook.
+#
+# If Datadoc is redeployed as a multi-user web app then this storage
+# strategy must be modified, since users will modify each others data.
+# See here: https://dash.plotly.com/sharing-data-between-callbacks
+
 # Global metadata container
 metadata: DataDocMetadata

--- a/datadoc/globals.py
+++ b/datadoc/globals.py
@@ -1,0 +1,4 @@
+from datadoc.DataDocMetadata import DataDocMetadata
+
+# Global metadata container
+metadata: DataDocMetadata

--- a/datadoc/tests/test_callbacks.py
+++ b/datadoc/tests/test_callbacks.py
@@ -1,0 +1,58 @@
+from copy import deepcopy
+from datadoc.DataDocMetadata import DataDocMetadata
+from datadoc.Model import VariableRole
+from datadoc.tests.utils import TEST_PARQUET_FILEPATH
+from datadoc.Callbacks import accept_variable_metadata_input
+import datadoc.globals as globals
+
+
+DATA_ORIGINAL = [
+    {
+        "short_name": "pers_id",
+        "variable_role": None,
+    },
+]
+DATA_VALID = [
+    {
+        "short_name": "pers_id",
+        "variable_role": "IDENTIFIER",
+    },
+]
+DATA_INVALID = [
+    {
+        "short_name": "pers_id",
+        "variable_role": 3.1415,
+    },
+]
+
+
+def test_accept_variable_metadata_input_no_change_in_data():
+    globals.metadata = DataDocMetadata(TEST_PARQUET_FILEPATH)
+    output = accept_variable_metadata_input(DATA_ORIGINAL, DATA_ORIGINAL)
+    assert output[0] == DATA_ORIGINAL
+    assert output[1] is False
+    assert output[2] == ""
+
+
+def test_accept_variable_metadata_input_new_data():
+    globals.metadata = DataDocMetadata(TEST_PARQUET_FILEPATH)
+    output = accept_variable_metadata_input(DATA_VALID, DATA_ORIGINAL)
+
+    assert (
+        globals.metadata.variables_metadata["pers_id"].variable_role
+        == VariableRole.IDENTIFIER
+    )
+    assert output[0] == DATA_VALID
+    assert output[1] is False
+    assert output[2] == ""
+
+
+def test_accept_variable_metadata_input_incorrect_data_type():
+    globals.metadata = DataDocMetadata(TEST_PARQUET_FILEPATH)
+    previous_metadata = deepcopy(globals.metadata.variables_metadata)
+    output = accept_variable_metadata_input(DATA_INVALID, DATA_ORIGINAL)
+
+    assert output[0] == DATA_ORIGINAL
+    assert output[1] is True
+    assert "validation error for DataDocVariable" in output[2]
+    assert globals.metadata.variables_metadata == previous_metadata

--- a/datadoc/tests/test_callbacks.py
+++ b/datadoc/tests/test_callbacks.py
@@ -1,8 +1,15 @@
 from copy import deepcopy
+
+from pytest import raises
+from pydantic import ValidationError
+
 from datadoc.DataDocMetadata import DataDocMetadata
-from datadoc.Model import VariableRole
+from datadoc.Model import DataSetState, VariableRole
 from datadoc.tests.utils import TEST_PARQUET_FILEPATH
-from datadoc.Callbacks import accept_variable_metadata_input
+from datadoc.Callbacks import (
+    accept_dataset_metadata_input,
+    accept_variable_metadata_input,
+)
 import datadoc.globals as globals
 
 
@@ -56,3 +63,18 @@ def test_accept_variable_metadata_input_incorrect_data_type():
     assert output[1] is True
     assert "validation error for DataDocVariable" in output[2]
     assert globals.metadata.variables_metadata == previous_metadata
+
+
+def test_accept_dataset_metadata_input_new_data():
+    globals.metadata = DataDocMetadata(TEST_PARQUET_FILEPATH)
+    output = accept_dataset_metadata_input(DataSetState.INPUT_DATA, "dataset_state")
+    assert output[0] is False
+    assert output[1] == ""
+    assert globals.metadata.dataset_metadata.dataset_state == DataSetState.INPUT_DATA
+
+
+def test_accept_dataset_metadata_input_incorrect_data_type():
+    globals.metadata = DataDocMetadata(TEST_PARQUET_FILEPATH)
+    output = accept_dataset_metadata_input(3.1415, "dataset_state")
+    assert output[0] is True
+    assert "validation error for DataDocDataSet" in output[1]

--- a/datadoc/tests/test_datadoc_metadata.py
+++ b/datadoc/tests/test_datadoc_metadata.py
@@ -5,7 +5,7 @@ import shutil
 import pytest
 
 from datadoc.Model import DataSetState
-from ..DataDocMetadata import DataDocMetadata
+from datadoc.DataDocMetadata import DataDocMetadata
 from .utils import (
     TEST_EXISTING_METADATA_FILE_NAME,
     TEST_EXISTING_METADATA_FILEPATH,

--- a/datadoc/tests/test_dataset_reader.py
+++ b/datadoc/tests/test_dataset_reader.py
@@ -2,7 +2,7 @@ import json
 import random
 
 from datadoc.Model import DataDocVariable, Datatype
-from ..DatasetReader import (
+from datadoc.DatasetReader import (
     KNOWN_BOOLEAN_TYPES,
     KNOWN_DATETIME_TYPES,
     KNOWN_FLOAT_TYPES,


### PR DESCRIPTION
Callbacks contain some central functionality for Datadoc and should therefore have unit tests. To accomplish this, we move the callback implementation to functions without the Dash `@app.callback` decorators, which allows us to control function input and output.

- Move callback function, create globals module
- Add tests for accept_variable_metadata_input
- Add tests for accept_dataset_metadata_input
- Minor tidying
